### PR TITLE
Add severity to CuratorHealthCheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <javassist.version>3.27.0-GA</javassist.version>
         <joda-time.version>2.10.6</joda-time.version>
         <kiwi.version>0.10.0</kiwi.version>
+        <kiwi.metrics-healthchecks-severity.version>0.9.0</kiwi.metrics-healthchecks-severity.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
         <zookeeper.version>3.4.14</zookeeper.version>
 
@@ -143,6 +144,12 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>dropwizard-config-providers</artifactId>
             <version>${dropwizard-config-providers.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kiwiproject</groupId>
+            <artifactId>metrics-healthchecks-severity</artifactId>
+            <version>${kiwi.metrics-healthchecks-severity.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/curator/health/CuratorHealthCheck.java
+++ b/src/main/java/org/kiwiproject/curator/health/CuratorHealthCheck.java
@@ -1,5 +1,9 @@
 package org.kiwiproject.curator.health;
 
+import static org.kiwiproject.metrics.health.HealthCheckResults.newHealthyResult;
+import static org.kiwiproject.metrics.health.HealthCheckResults.newUnhealthyResult;
+import static org.kiwiproject.metrics.health.HealthStatus.CRITICAL;
+
 import com.codahale.metrics.health.HealthCheck;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,33 +37,33 @@ public class CuratorHealthCheck extends HealthCheck {
     protected Result check() throws Exception {
         var state = client.getState();
         if (state == CuratorFrameworkState.LATENT) {
-            return Result.unhealthy("Curator [ %s ] has not been started - start() has not been called", connectString);
+            return newUnhealthyResult(CRITICAL, "Curator [ %s ] has not been started - start() has not been called", connectString);
         } else if (state == CuratorFrameworkState.STOPPED) {
-            return Result.unhealthy("Curator [ %s ] is stopped", connectString);
+            return newUnhealthyResult(CRITICAL, "Curator [ %s ] is stopped", connectString);
         } else if (state != CuratorFrameworkState.STARTED) {
-            return Result.unhealthy("Curator [ %s ] has unknown state: %s", connectString, state);
+            return newUnhealthyResult(CRITICAL, "Curator [ %s ] has unknown state: %s", connectString, state);
         }
 
         var zookeeperClient = client.getZookeeperClient();
         boolean connected = zookeeperClient.isConnected();
         LOG.trace("CuratorZookeeperClient is connected? {}", connected);
         if (!connected) {
-            return Result.unhealthy("Curator [ %s ] is started but is not connected", connectString);
+            return newUnhealthyResult(CRITICAL, "Curator [ %s ] is started but is not connected", connectString);
         }
 
         var zooKeeperState = zookeeperClient.getZooKeeper().getState();
         LOG.trace("ZK state: {}", zooKeeperState);
         if (zooKeeperState == ZooKeeper.States.CONNECTEDREADONLY) {
-            return Result.unhealthy("ZooKeeperState [ %s ] is connected but is read-only", connectString);
+            return newUnhealthyResult(CRITICAL, "ZooKeeperState [ %s ] is connected but is read-only", connectString);
         }
 
         try {
             List<String> znodes = client.getChildren().forPath("/");
             LOG.trace("Found znodes at root: {}", znodes);
-            return Result.healthy("Curator [ %s ] is healthy", connectString);
+            return newHealthyResult("Curator [ %s ] is healthy", connectString);
         } catch (Exception e) {
             LOG.trace("Error getting root-level znodes", e);
-            return Result.unhealthy("Curator [ %s ] - unable to read znodes at root path '/'", connectString);
+            return newUnhealthyResult(CRITICAL, "Curator [ %s ] - unable to read znodes at root path '/'", connectString);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/curator/health/CuratorHealthCheckTest.java
+++ b/src/test/java/org/kiwiproject/curator/health/CuratorHealthCheckTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.curator.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.metrics.health.HealthCheckResults.SEVERITY_DETAIL;
 import static org.kiwiproject.test.assertj.dropwizard.metrics.HealthCheckResultAssertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.metrics.health.HealthStatus;
 import org.kiwiproject.test.curator.CuratorTestingServerExtension;
 
 import java.util.concurrent.TimeUnit;
@@ -65,7 +67,8 @@ class CuratorHealthCheckTest {
 
         assertThat(healthCheck)
                 .isHealthy()
-                .hasMessage("Curator [ {} ] is healthy", zkConnectString);
+                .hasMessage("Curator [ {} ] is healthy", zkConnectString)
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.OK.name());
     }
 
     @Test
@@ -73,7 +76,8 @@ class CuratorHealthCheckTest {
         // Do not start client to remain in latent state
         assertThat(healthCheck)
                 .isUnhealthy()
-                .hasMessage("Curator [ {} ] has not been started - start() has not been called", zkConnectString);
+                .hasMessage("Curator [ {} ] has not been started - start() has not been called", zkConnectString)
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
     }
 
     @Test
@@ -83,7 +87,8 @@ class CuratorHealthCheckTest {
 
         assertThat(healthCheck)
                 .isUnhealthy()
-                .hasMessage("Curator [ {} ] is stopped", zkConnectString);
+                .hasMessage("Curator [ {} ] is stopped", zkConnectString)
+                .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
     }
 
     /**
@@ -113,7 +118,8 @@ class CuratorHealthCheckTest {
 
             assertThat(healthCheck)
                     .isUnhealthy()
-                    .hasMessage("Curator [ {} ] has unknown state: null", zkConnectString);
+                    .hasMessage("Curator [ {} ] has unknown state: null", zkConnectString)
+                    .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
         }
 
         @Test
@@ -123,7 +129,8 @@ class CuratorHealthCheckTest {
 
             assertThat(healthCheck)
                     .isUnhealthy()
-                    .hasMessage("Curator [ {} ] is started but is not connected", zkConnectString);
+                    .hasMessage("Curator [ {} ] is started but is not connected", zkConnectString)
+                    .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
         }
 
         @Test
@@ -137,7 +144,8 @@ class CuratorHealthCheckTest {
 
             assertThat(healthCheck)
                     .isUnhealthy()
-                    .hasMessage("ZooKeeperState [ {} ] is connected but is read-only", zkConnectString);
+                    .hasMessage("ZooKeeperState [ {} ] is connected but is read-only", zkConnectString)
+                    .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
         }
 
         @Test
@@ -155,7 +163,8 @@ class CuratorHealthCheckTest {
 
             assertThat(healthCheck)
                     .isUnhealthy()
-                    .hasMessage("Curator [ {} ] - unable to read znodes at root path '/'", zkConnectString);
+                    .hasMessage("Curator [ {} ] - unable to read znodes at root path '/'", zkConnectString)
+                    .hasDetail(SEVERITY_DETAIL, HealthStatus.CRITICAL.name());
         }
     }
 


### PR DESCRIPTION
All Curator and/or ZooKeeper problems are considered critical, since
it means the service will not be able to use Curator, e.g. if Curator
is not started, is stopped, if there is a ZooKeeper connection problem,
ZooKeeper is read-only, etc.

Fixes #20