### PR TITLE
Change CuratorConfig validation on zkConnectString

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <!-- Versions for required dependencies -->
         <classmate.version>1.5.1</classmate.version>
         <curator.version>2.13.0</curator.version>
-        <dropwizard-config-providers.version>0.8.0</dropwizard-config-providers.version>
+        <dropwizard-config-providers.version>0.9.0</dropwizard-config-providers.version>
         <dropwizard.version>2.0.16</dropwizard.version>
         <hibernate-validator.version>6.1.6.Final</hibernate-validator.version>
         <jackson.version>2.10.5</jackson.version>

--- a/src/main/java/org/kiwiproject/curator/config/CuratorConfig.java
+++ b/src/main/java/org/kiwiproject/curator/config/CuratorConfig.java
@@ -80,7 +80,6 @@ public class CuratorConfig {
     /**
      * The ZooKeeper connection string, e.g. {@code host1:2181,host2:2181,host3:2181}.
      */
-    @NotBlank
     @Getter(AccessLevel.NONE)
     private String zkConnectString;
 
@@ -191,10 +190,10 @@ public class CuratorConfig {
      * Return the ZooKeeper connect string using an explicitly configured value, or using the resolution of
      * the {@link ZooKeeperConfigProvider} in this instance.
      *
-     * @return the ZooKeeper connect string
-     * @throws IllegalStateException if there is no explicit connect string value or it cannot be resolved by
-     *                               the {@link ZooKeeperConfigProvider}
+     * @return the ZooKeeper connect string, or null if there is not a (non-blank) explicit value and the
+     * {@link ZooKeeperConfigProvider} cannot provide a value
      */
+    @NotBlank
     public String getZkConnectString() {
         if (isNotBlank(zkConnectString)) {
             return zkConnectString;
@@ -202,7 +201,6 @@ public class CuratorConfig {
             return zkConfigProvider.getConnectString();
         }
 
-        throw new IllegalStateException(
-                "No explicit connect string was given, and the ZooKeeperConfigProvider cannot provide a value");
+        return null;
     }
 }

--- a/src/test/java/org/kiwiproject/curator/config/CuratorConfigTest.java
+++ b/src/test/java/org/kiwiproject/curator/config/CuratorConfigTest.java
@@ -77,16 +77,24 @@ class CuratorConfigTest {
         }
 
         @Test
-        void shouldProviderDefaultValue_WhenNoExplicitValue() {
-            var configProvider = ZooKeeperConfigProvider.builder().build();
-            config = new CuratorConfig(configProvider);
-
+        void shouldProvideDefaultValue_WhenNoExplicitValue() {
             assertThat(config.getZkConnectString()).isEqualTo("localhost:2181");
         }
     }
 
     @Nested
     class Validation {
+
+        @BeforeEach
+        void setUp() {
+            var nullProvidingProvider = ZooKeeperConfigProvider.builder()
+                    .resolverStrategy(FieldResolverStrategy.<String>builder()
+                            .explicitValue(null)
+                            .build())
+                    .build();
+
+            config = new CuratorConfig(nullProvidingProvider);
+        }
 
         @Test
         void shouldNotAllowNull_ZkConnectString() {
@@ -143,7 +151,9 @@ class CuratorConfigTest {
 
             assertThat(copy)
                     .isNotSameAs(original)
-                    .isEqualToIgnoringGivenFields(original, "zkConfigProvider");
+                    .usingRecursiveComparison()
+                    .ignoringFields("zkConfigProvider")
+                    .isEqualTo(original);
         }
     }
 
@@ -173,7 +183,9 @@ class CuratorConfigTest {
 
             assertThat(copy)
                     .isNotSameAs(original)
-                    .isEqualToIgnoringGivenFields(original, "zkConnectString", "zkConfigProvider");
+                    .usingRecursiveComparison()
+                    .ignoringFields("zkConnectString", "zkConfigProvider")
+                    .isEqualTo(original);
 
             assertThat(copy.getZkConnectString()).isEqualTo(newZkConnectString);
         }


### PR DESCRIPTION
* Update dropwizard-config-providers to 0.9.0 (which changed
  ZooKeeperConfigProvider so that it doesn't have a default value)
* Move @NotBlank to the getZkConnectString() method and return null
  instead of throwing an IllegalStateException. This allows for proper
  validation of a CuratorConfig instance that validates the field is
  not blank or that the ZooKeeperConfigProvider is able to provide a
  non-blank value.

Fixes #50