### PR TITLE
Bump kiwiproject dependencies to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,23 +31,24 @@
         <!-- Versions for required dependencies -->
         <classmate.version>1.5.1</classmate.version>
         <curator.version>5.1.0</curator.version>
-        <dropwizard-config-providers.version>0.17.0</dropwizard-config-providers.version>
+        <dropwizard-config-providers.version>1.0.0</dropwizard-config-providers.version>
         <dropwizard.version>2.0.25</dropwizard.version>
         <hibernate-validator.version>6.1.7.Final</hibernate-validator.version>
         <jackson.version>2.10.5.1</jackson.version>
         <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta-el.version>3.0.4</jakarta-el.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <javassist.version>3.28.0-GA</javassist.version>
         <joda-time.version>2.10.10</joda-time.version>
-        <kiwi.version>0.25.0</kiwi.version>
-        <kiwi.metrics-healthchecks-severity.version>0.22.0</kiwi.metrics-healthchecks-severity.version>
+        <kiwi.version>1.0.0</kiwi.version>
+        <kiwi.metrics-healthchecks-severity.version>1.0.0</kiwi.metrics-healthchecks-severity.version>
         <metrics-jersey2.version>4.1.25</metrics-jersey2.version>
         <metrics-jetty9.version>4.1.25</metrics-jetty9.version>
         <zookeeper.version>3.7.0</zookeeper.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>0.21.0</kiwi-test.version>
+        <kiwi-test.version>1.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-curator</sonar.projectKey>
@@ -131,6 +132,10 @@
                     <artifactId>jakarta.annotation-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.el</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>jakarta.xml.bind</groupId>
                     <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
@@ -181,6 +186,13 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta.annotation-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>${jakarta-el.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* Bump dropwizard-config-providers from 0.17.0 to 1.0.0
* Bump jakarta-el version from 3.0.3 to 3.0.4 and add as explicit
  dependency to fix dependency convergence error
* Bump kiwi from 0.25.0 to 1.0.0
* Bump metrics-healthchecks-severity from 0.22.0 to 1.0.0
* Bump kiwi-test from 0.21.0 to 1.0.0