### PR TITLE
Handle invalid connect strings in ZooKeeperAvailabilityChecker

### DIFF
--- a/src/main/java/org/kiwiproject/curator/zookeeper/ZooKeeperAvailabilityChecker.java
+++ b/src/main/java/org/kiwiproject/curator/zookeeper/ZooKeeperAvailabilityChecker.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.curator.zookeeper;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
@@ -61,6 +62,15 @@ public class ZooKeeperAvailabilityChecker {
 
     private static Pair<String, Integer> toHostPortPair(String hostAndPort) {
         String[] splat = hostAndPort.split(":");
-        return Pair.of(splat[0], Integer.parseInt(splat[1]));
+        checkState(splat.length == 2, "host/port pair does not have exactly two elements: %s", hostAndPort);
+        return Pair.of(splat[0], getPortOrThrow(splat[1]));
+    }
+
+    private static int getPortOrThrow(String portString) {
+        try {
+            return Integer.parseInt(portString);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("port is not a number: " + portString, e);
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/curator/zookeeper/ZooKeeperAvailabilityCheckerTest.java
+++ b/src/test/java/org/kiwiproject/curator/zookeeper/ZooKeeperAvailabilityCheckerTest.java
@@ -3,6 +3,7 @@ package org.kiwiproject.curator.zookeeper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.curator.config.CuratorConfig;
 import org.kiwiproject.net.SocketChecker;
 import org.kiwiproject.test.junit.jupiter.params.provider.BlankStringArgumentsProvider;
@@ -111,6 +113,38 @@ class ZooKeeperAvailabilityCheckerTest {
         }
 
         @Nested
+        class ShouldThrowIllegalStateException {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "'zk1:foo', foo",
+                    "'zk1:2_182, zk2:2181', 2_182",
+                    "'zk1:2182, zk2:bar, zk3:2181', bar"
+            })
+            void whenGivenInvalidPort(String connectString, String expectedInvalidPort) {
+                System.out.println("connectString = " + connectString);
+                assertThatIllegalStateException()
+                        .isThrownBy(() -> checker.anyZooKeepersAvailable(connectString))
+                        .withCauseExactlyInstanceOf(NumberFormatException.class)
+                        .withMessage("port is not a number: %s", expectedInvalidPort);
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                    "'zk1, zk2:2181, zk3:2181', zk1",
+                    "'zk1:2181, zk2', zk2",
+                    "'zk1:2181, zk2:', zk2:",
+                    "'zk1:2181, zk2:2181, zk3', zk3"
+            })
+            void whenGivenInvalidHostAndPort(String connectString, String expectedInvalidHostAndPort) {
+                assertThatIllegalStateException()
+                        .isThrownBy(() -> checker.anyZooKeepersAvailable(connectString))
+                        .withNoCause()
+                        .withMessage("host/port pair does not have exactly two elements: %s", expectedInvalidHostAndPort);
+            }
+        }
+
+        @Nested
         class ShouldThrowIllegalArgumentException {
 
             @Test
@@ -128,6 +162,5 @@ class ZooKeeperAvailabilityCheckerTest {
                         .withMessage("ZooKeeper connect string must not be blank");
             }
         }
-
     }
 }


### PR DESCRIPTION
Add better handling of invalid ZooKeeper connect strings in ZooKeeperAvailabilityChecker. IllegalStateException is thrown when:
- a port is not a number
- the connection string does not contain host:port pairs

Fixes #202