### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dropwizard-curator</artifactId>
-    <version>1.1.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,13 +29,13 @@
     <properties>
 
         <!-- Versions for required dependencies -->
-        <dropwizard-config-providers.version>1.1.13</dropwizard-config-providers.version>
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
-        <kiwi.metrics-healthchecks-severity.version>1.0.13</kiwi.metrics-healthchecks-severity.version>
+        <dropwizard-config-providers.version>2.0.0</dropwizard-config-providers.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <kiwi.metrics-healthchecks-severity.version>2.0.0</kiwi.metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-curator</sonar.projectKey>

--- a/src/main/java/org/kiwiproject/curator/CuratorBundle.java
+++ b/src/main/java/org/kiwiproject/curator/CuratorBundle.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.curator;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.dropwizard.Configuration;
-import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
 import org.kiwiproject.curator.config.CuratorConfigured;

--- a/src/main/java/org/kiwiproject/curator/config/CuratorConfig.java
+++ b/src/main/java/org/kiwiproject/curator/config/CuratorConfig.java
@@ -7,6 +7,9 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import com.google.common.primitives.Ints;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,9 +17,6 @@ import lombok.ToString;
 import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.ZooKeeperConfigProvider;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/src/main/java/org/kiwiproject/curator/config/CuratorConfigured.java
+++ b/src/main/java/org/kiwiproject/curator/config/CuratorConfigured.java
@@ -1,7 +1,9 @@
 package org.kiwiproject.curator.config;
 
+import io.dropwizard.core.Configuration;
+
 /**
- * This interface is intended to be implemented by a Dropwizard {@link io.dropwizard.Configuration} class, in order
+ * This interface is intended to be implemented by a Dropwizard {@link Configuration} class, in order
  * to make the intent clear that an application requires a Curator configuration and for consistency across
  * applications. It is used by the Curator bundle provided in this library.
  *

--- a/src/test/java/org/kiwiproject/curator/CuratorBundleTest.java
+++ b/src/test/java/org/kiwiproject/curator/CuratorBundleTest.java
@@ -10,9 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.curator.framework.CuratorFramework;

--- a/src/test/java/org/kiwiproject/curator/config/CuratorConfigTest.java
+++ b/src/test/java/org/kiwiproject/curator/config/CuratorConfigTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.kiwiproject.test.validation.ValidationTestHelper.assertOnePropertyViolation;
 
 import io.dropwizard.util.Duration;
+import jakarta.validation.Validator;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,8 +18,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.config.provider.FieldResolverStrategy;
 import org.kiwiproject.config.provider.ZooKeeperConfigProvider;
 import org.kiwiproject.validation.KiwiValidations;
-
-import javax.validation.Validator;
 
 @DisplayName("CuratorConfig")
 @ExtendWith(SoftAssertionsExtension.class)


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9