### PR TITLE
Add useLock, withLock methods in CuratorLockHelper

### DIFF
--- a/src/main/java/org/kiwiproject/curator/CuratorLockHelper.java
+++ b/src/main/java/org/kiwiproject/curator/CuratorLockHelper.java
@@ -12,7 +12,11 @@ import org.kiwiproject.curator.exception.LockAcquisitionException;
 import org.kiwiproject.curator.exception.LockAcquisitionFailureException;
 import org.kiwiproject.curator.exception.LockAcquisitionTimeoutException;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 /**
  * Helper class for creating and managing Curator locks, and converting timeouts and exceptions thrown by Curator
@@ -108,6 +112,135 @@ public class CuratorLockHelper {
             releaseQuietly(lock);
         } else {
             LOG.trace("This process does not own lock [{}]. Nothing to do.", lock);
+        }
+    }
+
+    /**
+     * Tries to acquire the specified {@code lock}, waiting up to the specified timeout period.
+     * Once the lock is acquired, executes the specified {@code action}, then releases the lock.
+     * <p>
+     * If the action throws an exception, the lock is released, and the action's exception
+     * is propagated to the caller.
+     * <p>
+     * If Curator throws any exception, or if the timeout expires, the appropriate exception is thrown.
+     *
+     * @param lock   the distributed lock to acquire
+     * @param time   the timeout quantity
+     * @param unit   the timeout unit
+     * @param action the action to execute while holding the lock
+     * @throws LockAcquisitionFailureException if the lock throws any exception during acquisition
+     * @throws LockAcquisitionTimeoutException if the lock acquisition times out
+     */
+    public void useLock(InterProcessLock lock, long time, TimeUnit unit, Runnable action) {
+        try {
+            acquire(lock, time, unit);
+            action.run();
+        } finally {
+            releaseQuietly(lock);
+        }
+    }
+
+    /**
+     * Enumeration representing the type of error related to using a lock or returning a value
+     * while holding a lock.
+     */
+    public enum ErrorType {
+        /**
+         * Represents an error related to lock acquisition.
+         */
+        LOCK_ACQUISITION,
+
+        /**
+         * Represents an error related to a executing function or operation, e.g.
+         * executing a {@link Runnable} or getting a value from a {@link Supplier}.
+         */
+        OPERATION
+    }
+
+
+    /**
+     * Tries to acquire the specified {@code lock}, waiting up to the specified timeout period.
+     * Once the lock is acquired, executes the specified {@code action}, then releases the lock.
+     * <p>
+     * If the lock cannot be obtained for any reason, or the action throws an exception, the lock is released, and
+     * the {@code errorHandler} is called. The {@link ErrorType} can be used to determine the cause, to permit different
+     * handling for lock acquisition failures and action execution failures.
+     *
+     * @param lock         the distributed lock to acquire
+     * @param time         the timeout quantity
+     * @param unit         the timeout unit
+     * @param action       the action to execute while holding the lock
+     * @param errorHandler the action to take if the lock cannot be obtained, or if the action throws any exception
+     */
+    public void useLock(InterProcessLock lock,
+                        long time, TimeUnit unit,
+                        Runnable action,
+                        BiConsumer<ErrorType, RuntimeException> errorHandler) {
+        try {
+            useLock(lock, time, unit, action);
+        } catch(LockAcquisitionException e) {
+            errorHandler.accept(ErrorType.LOCK_ACQUISITION, e);
+        } catch (RuntimeException e) {
+            errorHandler.accept(ErrorType.OPERATION, e);
+        }
+    }
+
+    /**
+     * Tries to acquire the specified {@code lock}, waiting up to the specified timeout period.
+     * Once the lock is acquired, calls the {@code supplier} and returns the result of the its computation,
+     * then releases the lock.
+     * <p>
+     * If the supplier throws an exception, the lock is released, and the supplier's exception
+     * is propagated to the caller.
+     * <p>
+     * If Curator throws any exception, or if the timeout expires, the appropriate exception is thrown.
+     *
+     * @param <R>      the type of the result produced by the supplier
+     * @param lock     the distributed lock to acquire
+     * @param time     the timeout quantity
+     * @param unit     the timeout unit
+     * @param supplier The supplier providing the computation to be executed while holding the lock
+     * @return The result of the computation provided by the supplier
+     * @throws LockAcquisitionFailureException if the lock throws any exception during acquisition
+     * @throws LockAcquisitionTimeoutException if the lock acquisition times out
+     */
+    public <R> R withLock(InterProcessLock lock, long time, TimeUnit unit, Supplier<R> supplier) {
+        try {
+            acquire(lock, time, unit);
+            return supplier.get();
+        } finally {
+            releaseQuietly(lock);
+        }
+    }
+
+    /**
+     * Tries to acquire the specified {@code lock}, waiting up to the specified timeout period.
+     * Once the lock is acquired, calls the {@code supplier} and returns the result of the its computation,
+     * then releases the lock.
+     * <p>
+     * If the lock cannot be obtained for any reason, or the action throws an exception, the lock is released, and
+     * the {@code errorHandler} is called. The {@link ErrorType} can be used to determine the cause, to permit different
+     * handling for lock acquisition failures and action execution failures. Note that because this method
+     * requires a return value, the error handler must provide one, though it could be null.
+     *
+     * @param <R>          the type of the result produced by the supplier
+     * @param lock         the distributed lock to acquire
+     * @param time         the timeout quantity
+     * @param unit         the timeout unit
+     * @param supplier     the supplier providing the computation to be executed while holding the lock
+     * @param errorHandler the action to take if the lock cannot be obtained, or if the supplier throws any exception
+     * @return The result of the computation provided by the supplier
+     */
+    public <R> R withLock(InterProcessLock lock,
+                          long time, TimeUnit unit,
+                          Supplier<R> supplier,
+                          BiFunction<ErrorType, RuntimeException, R> errorHandler) {
+        try {
+            return withLock(lock, time, unit, supplier) ;
+        } catch(LockAcquisitionException e) {
+            return errorHandler.apply(ErrorType.LOCK_ACQUISITION, e);
+        } catch (RuntimeException e) {
+            return errorHandler.apply(ErrorType.OPERATION, e);
         }
     }
 }

--- a/src/main/java/org/kiwiproject/curator/CuratorLockHelper.java
+++ b/src/main/java/org/kiwiproject/curator/CuratorLockHelper.java
@@ -12,7 +12,6 @@ import org.kiwiproject.curator.exception.LockAcquisitionException;
 import org.kiwiproject.curator.exception.LockAcquisitionFailureException;
 import org.kiwiproject.curator.exception.LockAcquisitionTimeoutException;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;

--- a/src/test/java/org/kiwiproject/curator/CuratorLockHelperTest.java
+++ b/src/test/java/org/kiwiproject/curator/CuratorLockHelperTest.java
@@ -2,13 +2,18 @@ package org.kiwiproject.curator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Supplier;
+import lombok.Getter;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.WatcherRemoveCuratorFramework;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
@@ -16,10 +21,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.curator.CuratorLockHelper.ErrorType;
 import org.kiwiproject.curator.exception.LockAcquisitionFailureException;
 import org.kiwiproject.curator.exception.LockAcquisitionTimeoutException;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 @DisplayName("CuratorLockHelper")
 class CuratorLockHelperTest {
@@ -141,6 +151,298 @@ class CuratorLockHelperTest {
     private static class CannotAcquireLockException extends RuntimeException {
         CannotAcquireLockException(String message) {
             super(message);
+        }
+    }
+
+    @Nested
+    class UseLock {
+
+        @Test
+        void shouldCallRunnable_WhenAcquiresLock() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var action = new TrackingRunnable();
+            lockHelper.useLock(lock, 3, TimeUnit.SECONDS, action);
+
+            assertThat(action.wasCalled).isTrue();
+
+            verify(lock).acquire(3, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldThrowLockAcquisitionFailureException_WhenFails_DueToException() throws Exception {
+            doThrow(new CannotAcquireLockException("oops, can't touch this lock"))
+                    .when(lock)
+                    .acquire(anyLong(), any(TimeUnit.class));
+
+            var action = new TrackingRunnable();
+            assertThatThrownBy(() -> lockHelper.useLock(lock, 2, TimeUnit.SECONDS, action))
+                    .isExactlyInstanceOf(LockAcquisitionFailureException.class);
+            assertThat(action.wasCalled).isFalse();
+
+            verify(lock).acquire(2, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldThrowLockAcquisitionTimeoutException_WhenFails_DueToTimeout() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+            var action = new TrackingRunnable();
+            assertThatThrownBy(() -> lockHelper.useLock(lock, 1, TimeUnit.SECONDS, action))
+                    .isExactlyInstanceOf(LockAcquisitionTimeoutException.class);
+            assertThat(action.wasCalled).isFalse();
+
+            verify(lock).acquire(1, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldReleaseLock_IfActionThrowsAnException() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var action = new ThrowingRunnable();
+            assertThatThrownBy(() -> lockHelper.useLock(lock, 1, TimeUnit.SECONDS, action))
+                    .isExactlyInstanceOf(UncheckedIOException.class);
+
+            verify(lock).acquire(1, TimeUnit.SECONDS);
+            verify(lock).release();
+        }
+    }
+
+    @Nested
+    class UseLockWithErrorHandler {
+
+        @Test
+        void shouldCallRunnable_WhenAcquiresLock() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var action = new TrackingRunnable();
+            var errorConsumer = new ErrorConsumer();
+            lockHelper.useLock(lock, 5, TimeUnit.SECONDS, action, errorConsumer);
+
+            assertThat(action.wasCalled).isTrue();
+            assertThat(errorConsumer.wasCalled).isFalse();
+
+            verify(lock).acquire(5, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldCallErrorHandler_WhenLockAcquisitionFails() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+            var action = new TrackingRunnable();
+            var errorConsumer = new ErrorConsumer();
+            lockHelper.useLock(lock, 5, TimeUnit.SECONDS, action, errorConsumer);
+
+            assertThat(action.wasCalled).isFalse();
+            assertThat(errorConsumer.wasCalled).isTrue();
+            assertThat(errorConsumer.errorType).isEqualTo(ErrorType.LOCK_ACQUISITION);
+            assertThat(errorConsumer.e).isExactlyInstanceOf(LockAcquisitionTimeoutException.class);
+
+            verify(lock).acquire(5, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldCallErrorHandler_WhenActionThrowsException() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var action = new ThrowingRunnable();
+            var errorConsumer = new ErrorConsumer();
+            lockHelper.useLock(lock, 3, TimeUnit.SECONDS, action, errorConsumer);
+
+            assertThat(errorConsumer.wasCalled).isTrue();
+            assertThat(errorConsumer.errorType).isEqualTo(ErrorType.OPERATION);
+            assertThat(errorConsumer.e).isExactlyInstanceOf(UncheckedIOException.class);
+
+            verify(lock).acquire(3, TimeUnit.SECONDS);
+        }
+    }
+
+    @Nested
+    class WithLock {
+
+        @Test
+        void shouldReturnResultOfSupplier_WhenAcquiresLock() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var number = 84L;
+            var supplier = new TrackingSupplier(number);
+            var result = lockHelper.withLock(lock, 2, TimeUnit.SECONDS, supplier);
+
+            assertThat(result).isEqualTo(number);
+            assertThat(supplier.wasCalled).isTrue();
+
+            verify(lock).acquire(2, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldThrowLockAcquisitionFailureException_WhenFails_DueToException() throws Exception {
+            doThrow(new CannotAcquireLockException("oops, can't touch this lock"))
+                    .when(lock)
+                    .acquire(anyLong(), any(TimeUnit.class));
+
+            var supplier = new TrackingSupplier();
+            assertThatThrownBy(() -> lockHelper.withLock(lock, 5, TimeUnit.SECONDS, supplier))
+                    .isExactlyInstanceOf(LockAcquisitionFailureException.class);
+            assertThat(supplier.wasCalled).isFalse();
+
+            verify(lock).acquire(5, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldThrowLockAcquisitionTimeoutException_WhenFails_DueToTimeout() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+            var supplier = new TrackingSupplier();
+            assertThatThrownBy(() -> lockHelper.withLock(lock, 2, TimeUnit.SECONDS, supplier))
+                    .isExactlyInstanceOf(LockAcquisitionTimeoutException.class);
+            assertThat(supplier.wasCalled).isFalse();
+
+            verify(lock).acquire(2, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldReleaseLock_IfSupplierThrowsAnException() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var supplier = new ThrowingSupplier();
+            assertThatThrownBy(() -> lockHelper.withLock(lock, 5, TimeUnit.SECONDS, supplier))
+                    .isExactlyInstanceOf(UncheckedIOException.class);
+
+            verify(lock).acquire(5, TimeUnit.SECONDS);
+            verify(lock).release();
+        }
+    }
+
+    @Nested
+    class WithLockWithErrorHandler {
+
+        @Test
+        void shouldReturnResultOfSupplier_WhenAcquiresLock() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var number = 84L;
+            var supplier = new TrackingSupplier(number);
+            var errorHandler = new ErrorHandlerFn<>(21L);
+            var result = lockHelper.withLock(lock, 2, TimeUnit.SECONDS, supplier, errorHandler);
+
+            assertThat(result).isEqualTo(number);
+            assertThat(supplier.wasCalled).isTrue();
+            assertThat(errorHandler.wasCalled).isFalse();
+
+            verify(lock).acquire(2, TimeUnit.SECONDS);
+        }
+
+        @Test
+        void shouldCallErrorHandlerFunction_WhenLockAcquisitionFails() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+            var supplier = new TrackingSupplier();
+            var fallback = 42L;
+            var errorHandler = new ErrorHandlerFn<>(fallback);
+            var result = lockHelper.withLock(lock, 2, TimeUnit.SECONDS, supplier, errorHandler);
+
+            assertThat(supplier.wasCalled).isFalse();
+            assertThat(result).isEqualTo(fallback);
+            assertThat(errorHandler.wasCalled).isTrue();
+            assertThat(errorHandler.errorType).isEqualTo(ErrorType.LOCK_ACQUISITION);
+            assertThat(errorHandler.e).isExactlyInstanceOf(LockAcquisitionTimeoutException.class);
+        }
+
+        @Test
+        void shouldCallErrorHandlerFunction_WhenActionThrowsException() throws Exception {
+            when(lock.acquire(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+            var supplier = new ThrowingSupplier();
+            var fallback = 84;
+            var errorHandler = new ErrorHandlerFn<>(fallback);
+            var result = lockHelper.withLock(lock, 3, TimeUnit.SECONDS, supplier, errorHandler);
+
+            assertThat(result).isEqualTo(fallback);
+            assertThat(errorHandler.wasCalled).isTrue();
+            assertThat(errorHandler.errorType).isEqualTo(ErrorType.OPERATION);
+            assertThat(errorHandler.e).isExactlyInstanceOf(UncheckedIOException.class);
+        }
+    }
+
+    @Getter
+    static class TrackingRunnable implements Runnable {
+
+        boolean wasCalled;
+
+        @Override
+        public void run() {
+            wasCalled = true;
+        }
+    }
+
+    static class ThrowingRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            throw new UncheckedIOException(new IOException("I/O error"));
+        }
+    }
+
+    @Getter
+    static class TrackingSupplier implements Supplier<Long> {
+
+        TrackingSupplier() {
+            this(42L);
+        }
+
+        TrackingSupplier(Long result) {
+            this.result = result;
+        }
+
+        final Long result;
+        boolean wasCalled;
+
+        @Override
+        public Long get() {
+            wasCalled = true;
+            return result;
+        }
+    }
+
+    static class ThrowingSupplier implements Supplier<Integer> {
+
+        @Override
+        public Integer get() {
+            throw new UncheckedIOException(new IOException("I/O error"));
+        }
+    }
+
+    static class ErrorConsumer implements BiConsumer<ErrorType, RuntimeException> {
+
+        boolean wasCalled;
+        ErrorType errorType;
+        RuntimeException e;
+
+        @Override
+        public void accept(ErrorType errorType, RuntimeException e) {
+            wasCalled = true;
+            this.errorType = errorType;
+            this.e = e;
+        }
+    }
+
+    static class ErrorHandlerFn<R> implements BiFunction<ErrorType, RuntimeException, R> {
+
+        final R fallback;
+        boolean wasCalled;
+        ErrorType errorType;
+        RuntimeException e;
+
+        public ErrorHandlerFn(R fallback) {
+            this.fallback = fallback;
+        }
+
+        @Override
+        public R apply(ErrorType errorType, RuntimeException e) {
+            wasCalled = true;
+            this.errorType = errorType;
+            this.e = e;
+            return fallback;
         }
     }
 }


### PR DESCRIPTION
* Add useLock and withLock with automatic lock acquisition and release
to CuratorLockHelper
* There are two variants of each, one that propagates exceptions and
one that provides an error handler

Closes #251