### PR TITLE
Remove redundant Sonar properties from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-curator</sonar.projectKey>
-        <sonar.organization>kiwiproject</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Remove the redundant sonar.organization and sonar.host.url properties from pom.xml. These properties are already defined in kiwi-parent and do not need to be redefined here.