### PR TITLE
chore: rename property to match artifact ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dropwizard-config-providers.version>3.0.2</dropwizard-config-providers.version>
         <kiwi.version>5.3.1</kiwi.version>
         <kiwi-bom.version>3.2.0</kiwi-bom.version>
-        <kiwi.metrics-healthchecks-severity.version>3.0.2</kiwi.metrics-healthchecks-severity.version>
+        <metrics-healthchecks-severity.version>3.0.2</metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
         <kiwi-test.version>4.1.0</kiwi-test.version>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>metrics-healthchecks-severity</artifactId>
-            <version>${kiwi.metrics-healthchecks-severity.version}</version>
+            <version>${metrics-healthchecks-severity.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Rename kiwi.metrics-healthchecks-severity.version to metrics-healthchecks-severity.version so that the property name matches the format that will be expected by kiwi-star-deployer.

Closes #400