### PR TITLE
chore: bump kiwi dependency versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <properties>
 
         <!-- Versions for required dependencies -->
-        <dropwizard-config-providers.version>3.0.2</dropwizard-config-providers.version>
-        <kiwi.version>5.3.1</kiwi.version>
-        <kiwi-bom.version>3.2.0</kiwi-bom.version>
-        <metrics-healthchecks-severity.version>3.0.2</metrics-healthchecks-severity.version>
+        <dropwizard-config-providers.version>3.0.3</dropwizard-config-providers.version>
+        <kiwi.version>5.4.0</kiwi.version>
+        <kiwi-bom.version>3.3.0</kiwi-bom.version>
+        <metrics-healthchecks-severity.version>3.1.0</metrics-healthchecks-severity.version>
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>4.1.0</kiwi-test.version>
+        <kiwi-test.version>4.2.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dropwizard-curator</sonar.projectKey>


### PR DESCRIPTION
* dropwizard-config-providers 3.0.3
* kiwi 5.4.0
* kiwi-bom 3.3.0
* metrics-healthchecks-severity 3.1.0
* kiwi-test 4.2.0